### PR TITLE
feat: Suggest MDN

### DIFF
--- a/1/search.txt
+++ b/1/search.txt
@@ -15,4 +15,4 @@ https://code.visualstudio.com/download
 		
 5- https://www.w3schools.com/html/html_intro.asp
 6- https://www.w3schools.com/html/html_basic.asp
-
+7- https://developer.mozilla.org/en-US/docs/Web/HTML


### PR DESCRIPTION
MDN (Mozilla Developer Network) is considered a better source for learning HTML compared to W3Schools for several reasons.

1 - MDN is a comprehensive resource that covers all aspects of web development, including HTML, CSS, JavaScript, and more, while W3Schools only focuses on HTML and related technologies. 

2 - MDN is maintained by a non-profit organization, Mozilla, and is considered one of the most trustworthy sources for web development information, whereas W3Schools is a commercial site that is known to ***contain outdated information*** and often lacks depth in its explanations. 

3 - __MDN's content is regularly updated and reviewed by experts in the field__, ensuring that the information provided is up-to-date and accurate, whereas W3Schools does not have the same level of review and update processes in place. All these factors make MDN a more reliable and trustworthy source for learning HTML and web development in general.